### PR TITLE
update wordpress.org contributor list, sync readme with wordpress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Storefront Homepage Contact Section ===
-Contributors: tiagonoronha, woothemes, rynald0s, automattic
+Contributors: woocommerce,automattic,tiagonoronha,woothemes,rynald0s
 Tags: woocommerce, ecommerce, storefront, contact, form, map, email
 Requires at least: 4.0
 Tested up to: 4.9


### PR DESCRIPTION
This PR updates the WordPress.org `readme.txt` to make `woocommerce` the `Developer` of the plugin.

ref: p1596823265254600-sl